### PR TITLE
Introduce @github/webauthn-json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.437.0",
+    "@github/webauthn-json": "^2.1.1",
     "@vueuse/core": "^12.8.2",
     "buefy": "npm:@ntohq/buefy-next@0.2.0",
-    "js-base64": "^3.7.5",
     "pinia": "^2.1.6",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"

--- a/app/src/views/SignIn.vue
+++ b/app/src/views/SignIn.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { BButton, BField, BInput } from 'buefy';
-import { Base64 } from 'js-base64';
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { RouterLink, useRouter } from 'vue-router';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,16 @@ importers:
         specifier: ~5.2.2
         version: 5.2.2
 
+  passquito-client-js:
+    dependencies:
+      '@github/webauthn-json':
+        specifier: ^2.1.1
+        version: 2.1.1
+    devDependencies:
+      typescript:
+        specifier: ~5.2.2
+        version: 5.2.2
+
 packages:
 
   '@ampproject/remapping@2.3.0':
@@ -578,6 +588,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@github/webauthn-json@2.1.1':
+    resolution: {integrity: sha512-XrftRn4z75SnaJOmZQbt7Mk+IIjqVHw+glDGOxuHwXkZBZh/MBoRS7MHjSZMDaLhT4RjN2VqiEU7EOYleuJWSQ==}
+    hasBin: true
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3121,6 +3135,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.2':
     optional: true
+
+  '@github/webauthn-json@2.1.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
### Proposed changes

Introduces [`@github/webauthn-json`](https://github.com/github/webauthn-json/tree/main) to replace the in-house code that performs conversion between each of the following types and its JSON-friendly format:
- CredentialCreationOptions
- CredentialRequestOptions
- PublicKeyCredential

Uninstalls `js-base64` because it is no longer used. Removes a line that imports `js-base64` which was meaningless but I forgot to remove.

### Related issues

N/A

## Summary by Sourcery

Replace in-house WebAuthn JSON conversion code with @github/webauthn-json library

New Features:
- Integrate @github/webauthn-json library for standardized WebAuthn JSON conversions

Enhancements:
- Simplify WebAuthn-related type conversions by using a dedicated library
- Remove custom encoding and decoding functions for WebAuthn credentials

Chores:
- Remove js-base64 dependency
- Remove custom WebAuthn JSON conversion functions