### PR TITLE
Introduce CredentialsApi

### DIFF
--- a/app/src/utils/credentials-api.ts
+++ b/app/src/utils/credentials-api.ts
@@ -1,0 +1,90 @@
+import type {
+  CognitoTokens,
+  UserInfo,
+  VerifiedUserInfo,
+} from './passquito-types';
+
+/**
+ * Registration session.
+ *
+ * @beta
+ */
+export interface RegistrationSession {
+  /** Session ID. */
+  sessionId: string;
+
+  /** Credential creation options for a public key. */
+  credentialCreationOptions: CredentialCreationOptions;
+}
+
+/**
+ * Authentication session.
+ *
+ * @beta
+ */
+export interface AuthenticationSession {
+  /** Session ID. */
+  sessionId: string;
+
+  /** Credential request options for a public key. */
+  credentialRequestOptions: CredentialRequestOptions;
+}
+
+/**
+ * Service that provides access to the Credentials API.
+ *
+ * @beta
+ */
+export interface CredentialsApi {
+  /**
+   * Starts a registration session of a new user.
+   */
+  startRegistration(userInfo: UserInfo): Promise<RegistrationSession>;
+
+  /**
+   * Starts a registration session of a new credential for an existing user.
+   */
+  startRegistrationForVerifiedUser(userInfo: VerifiedUserInfo): Promise<RegistrationSession>;
+
+  /**
+   * Finishes a registration session.
+   *
+   * @param sessionId - Session ID returned from {@link startRegistration} or
+   *   {@link startRegistrationForVerifiedUser}.
+   */
+  finishRegistration(sessionId: string, credential: PublicKeyCredential): Promise<void>;
+
+  /**
+   * Returns a credential request options for a discoverable credential.
+   */
+  getDiscoverableCredentialRequestOptions(): Promise<CredentialRequestOptions>;
+
+  /**
+   * Starts an authentication session.
+   *
+   * @remarks
+   *
+   * You have to call this function even if you are conducting authentication
+   * with a discoverable credential.
+   *
+   * @param userId - Passquito user ID.
+   */
+  startAuthentication(userId: string): Promise<AuthenticationSession>;
+
+  /**
+   * Finishes an authentication session.
+   */
+  finishAuthentication(
+    sessionId: string,
+    userId: string,
+    credential: PublicKeyCredential,
+  ): Promise<CognitoTokens>;
+
+  /**
+   * Refreshes the Cognito tokens associated with a given refresh token.
+   *
+   * @returns  Refreshed Cognito tokens. `undefined` if the refresh token is
+   *   invalid or expired.
+   */
+  refreshTokens(refreshToken: string): Promise<CognitoTokens | undefined>;
+}

--- a/app/src/utils/passquito-types.ts
+++ b/app/src/utils/passquito-types.ts
@@ -1,0 +1,60 @@
+/**
+ * User information for registration.
+ *
+ * @remarks
+ *
+ * Neither `username` nor `displayName` have to be unique.
+ * They are for display purposes only.
+ *
+ * @beta
+ */
+export interface UserInfo {
+  /** Username. Must not be empty. */
+  username: string;
+
+  /** Display name. */
+  displayName: string;
+}
+
+/**
+ * Information on a verified user who bears an ID token.
+ *
+ * @beta
+ */
+export interface VerifiedUserInfo {
+  /** ID token of the verified user. */
+  idToken: string;
+
+  /** User information. */
+  userInfo: UserInfo;
+}
+
+/**
+ * Cognito tokens.
+ *
+ * @beta
+ */
+export interface CognitoTokens {
+  /** ID token. */
+  idToken: string;
+
+  /** Access token. */
+  accessToken: string;
+
+  /** Refresh token. */
+  refreshToken: string;
+
+  /** Duration of the token in seconds. */
+  expiresIn: number;
+
+  /**
+   * Activation time represented as the number of milliseconds since 00:00:00
+   * on January 1, 1970 in UTC.
+   *
+   * @remarks
+   *
+   * Expiration time of tokens is approximately this value plus `expiresIn` ×
+   * 1000.
+   */
+  activatedAt: number;
+}


### PR DESCRIPTION
### Proposed changes

Introduces a new interface `CredentialsApi` in`src/utils/credentials-api.ts`, which models access to Passquito's Credentials API. Makes calls to the Credentials API through `CredentialsApi` in `src/utils/passquito.ts`. Although the API calls are still embedded in `src/utils/passquito.ts`, this commit is a preparatory step and the API calls will be separated in an upcoming commit.

Extracts common types in `src/utils/passquito-types.ts`.

### Related issues

N/A

## Summary by Sourcery

Introduce a new CredentialsApi interface to abstract and centralize API calls related to user credentials and authentication in the Passquito application

New Features:
- Create a new CredentialsApi interface that encapsulates all credential-related API interactions

Enhancements:
- Extract common types into a separate passquito-types.ts file
- Refactor existing API calls to use the new CredentialsApi interface

Chores:
- Improve code organization by separating concerns and introducing a more modular approach to API interactions