### PR TITLE
Install Buefy from the Buefy org

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+@buefy:registry=https://npm.pkg.github.com
 @codemonger-io:registry=https://npm.pkg.github.com

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,1 +1,0 @@
-# @ntohq:registry=https://npm.pkg.github.com

--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,7 @@
     "@codemonger-io/passquito-client-js": "workspace:*",
     "@github/webauthn-json": "^2.1.1",
     "@vueuse/core": "^12.8.2",
-    "buefy": "npm:@ntohq/buefy-next@0.2.0",
+    "buefy": "npm:@buefy/buefy@1.0.0-204a88af3e6f339eb372bf60261f46996c321967",
     "pinia": "^2.1.6",
     "vue": "^3.3.4",
     "vue-router": "^4.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^12.8.2
         version: 12.8.2(typescript@5.2.2)
       buefy:
-        specifier: npm:@ntohq/buefy-next@0.2.0
-        version: '@ntohq/buefy-next@0.2.0(vue@3.5.13(typescript@5.2.2))'
+        specifier: npm:@buefy/buefy@1.0.0-204a88af3e6f339eb372bf60261f46996c321967
+        version: '@buefy/buefy@1.0.0-204a88af3e6f339eb372bf60261f46996c321967(vue@3.5.13(typescript@5.2.2))'
       pinia:
         specifier: ^2.1.6
         version: 2.3.1(typescript@5.2.2)(vue@3.5.13(typescript@5.2.2))
@@ -634,6 +634,11 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@buefy/buefy@1.0.0-204a88af3e6f339eb372bf60261f46996c321967':
+    resolution: {integrity: sha512-H/gbl0rW/g9dliO/b3I8ZX4tJa9gqUQyihsJw/nBw30r1d9fqocUNkgsL4HfOJARjtmuRVbihCzYv4MlOdTHvw==, tarball: https://npm.pkg.github.com/download/@buefy/buefy/1.0.0-204a88af3e6f339eb372bf60261f46996c321967/40991f48c8e342faa77cd882f328744f6281e096}
+    peerDependencies:
+      vue: ^3.0.0
+
   '@codemonger-io/cdk-cors-utils@0.4.0-8678c3d':
     resolution: {integrity: sha512-z+Gs2ioXaPE85sAgfkBTQzdrkgy2aSRPDLFJSx/vOYY7klqcxRR9WGOPmHbBfz7UvPPDsGFFx+7VQ3xeulNBnQ==, tarball: https://npm.pkg.github.com/download/@codemonger-io/cdk-cors-utils/0.4.0-8678c3d/58c448b96eef7e33d403074c181fcaa44f18bdfd}
     engines: {node: '>=12.0.0'}
@@ -1104,11 +1109,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@ntohq/buefy-next@0.2.0':
-    resolution: {integrity: sha512-I8/8eM2eOxZCl5igqYn274fpbgpJEPWGULvVDOXdT2WOaiWA8AHQPsT9WfknW3DENuYEWyMzKTyVI74R/Yl3BA==}
-    peerDependencies:
-      vue: ^3.0.0
-
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
@@ -1224,11 +1224,6 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.39.0':
     resolution: {integrity: sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.6.1':
-    resolution: {integrity: sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==}
     cpu: [x64]
     os: [linux]
 
@@ -4684,6 +4679,10 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@buefy/buefy@1.0.0-204a88af3e6f339eb372bf60261f46996c321967(vue@3.5.13(typescript@5.2.2))':
+    dependencies:
+      vue: 3.5.13(typescript@5.2.2)
+
   '@codemonger-io/cdk-cors-utils@0.4.0-8678c3d(aws-cdk-lib@2.188.0(constructs@10.4.2))':
     dependencies:
       aws-cdk-lib: 2.188.0(constructs@10.4.2)
@@ -5143,12 +5142,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@ntohq/buefy-next@0.2.0(vue@3.5.13(typescript@5.2.2))':
-    dependencies:
-      vue: 3.5.13(typescript@5.2.2)
-    optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.6.1
-
   '@one-ini/wasm@0.1.1': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -5232,9 +5225,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.39.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.6.1':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.39.0':


### PR DESCRIPTION
Installs `buefy` from the Buefy org. As only developer releases are currently available, installs it from GitHub Packages.

Hoists the `.npmrc` configuration in the `app` folder to the root.