### PR TITLE
Publish developer package of passquito-client-js

### DIFF
--- a/.github/workflows/publish-developer-packages.yml
+++ b/.github/workflows/publish-developer-packages.yml
@@ -15,3 +15,9 @@ jobs:
 
     secrets:
       package-reader-pat: ${{ secrets.PACKAGE_READER_PAT }}
+
+  publish-passquito-client-js:
+    uses: ./.github/workflows/publish-passquito-client-js.yml
+
+    secrets:
+      package-reader-pat: ${{ secrets.PACKAGE_READER_PAT }}

--- a/.github/workflows/publish-passquito-cdk-construct.yml
+++ b/.github/workflows/publish-passquito-cdk-construct.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.package-reader-pat }}
-        run: pnpm install
+        run: pnpm install --filter "${{ steps.package_info.outputs.name }}"
 
       - name: Build distribution
         run: pnpm run -r --filter "${{ steps.package_info.outputs.name }}" build

--- a/.github/workflows/publish-passquito-client-js.yml
+++ b/.github/workflows/publish-passquito-client-js.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.package-reader-pat }}
-        run: pnpm install
+        run: pnpm install --filter "${{ steps.package_info.outputs.name }}"
 
       - name: Build distribution
         run: pnpm run -r --filter "${{ steps.package_info.outputs.name }}" build

--- a/.github/workflows/publish-passquito-client-js.yml
+++ b/.github/workflows/publish-passquito-client-js.yml
@@ -1,0 +1,74 @@
+name: Publish a developer package of passquito-client-js
+
+on:
+  workflow_call:
+    secrets:
+      package-reader-pat:
+        description: "GitHub personal access token (PAT) which has at least the 'read:packages' scope to read packages from GitHub Packages."
+        required: true
+
+env:
+  node-version: 22.x
+  pnpm-version: 10
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get short commit hash
+        id: commit_hash
+        run: echo "short_commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # pnpm has to be installed prior to running actions/setup-node
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.pnpm-version }}
+          run_install: false
+
+      - name: Setup Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: pnpm
+          registry-url: 'https://npm.pkg.github.com'
+
+      # appends the short commit hash to the version
+      # 1. reads package.json
+      # 2. replaces version in package.json
+      - name: Extract package information
+        id: package_info
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: passquito-client-js/package.json
+      - name: Append short commit hash to version
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: passquito-client-js/package.json
+          version: ${{ steps.package_info.outputs.version }}-${{ steps.commit_hash.outputs.short_commit_hash }}
+
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.package-reader-pat }}
+        run: pnpm install
+
+      - name: Build distribution
+        run: pnpm run -r --filter "${{ steps.package_info.outputs.name }}" build
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm publish -r \
+            --filter "${{ steps.package_info.outputs.name }}" \
+            --no-git-checks


### PR DESCRIPTION
Introduces a new GitHub Actions workflow `publish-passquito-client-js` which publishes a developer package to the npm registry managed by GitHub Packages. The `publish-developer-packages` calls it when commits are pushed to the `main` branch.

As `passquito-client-js` depends on a developer release of Buefy, you have to configure the `PACKAGE_READER_PAT` secret with a PAT which has at least the `read:packages` scope.

Also includes a minor improvement in the `publish-passquito-cdk-construct` workflow.

## Summary by Sourcery

Introduce a new reusable GitHub Actions workflow to publish a developer package of passquito-client-js with commit-hash versioning, integrate it into the main developer packages pipeline, and refine dependency installation in the CDK construct workflow.

New Features:
- Create a `publish-passquito-client-js.yml` workflow to build and publish the passquito-client-js developer package to GitHub Packages, appending a short commit hash to the version.

Enhancements:
- Modify `publish-passquito-cdk-construct.yml` to install dependencies only for the target package using `pnpm install --filter`.

CI:
- Add a `publish-passquito-client-js` job to the `publish-developer-packages.yml` workflow triggered on pushes to `main`.