### PR TITLE
Run tests for passquito-cdk-construct on GitHub Actions

### DIFF
--- a/.github/workflows/publish-passquito-cdk-construct.yml
+++ b/.github/workflows/publish-passquito-cdk-construct.yml
@@ -61,6 +61,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.package-reader-pat }}
         run: pnpm install --filter "${{ steps.package_info.outputs.name }}"
 
+      - name: Run tests
+        run: pnpm run -r --filter "${{ steps.package_info.outputs.name }}" test
+
       - name: Build distribution
         run: pnpm run -r --filter "${{ steps.package_info.outputs.name }}" build
 

--- a/.github/workflows/test-passquito-cdk-construct.yml
+++ b/.github/workflows/test-passquito-cdk-construct.yml
@@ -1,0 +1,43 @@
+name: "Test passquito-cdk-construct"
+
+on:
+  push:
+    branches-ignore:
+      - main # workflow to publish a developer package should run tests
+  pull_request:
+    branches:
+      - main
+
+env:
+  node-version: 22.x
+  pnpm-version: 10
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # pnpm has to be installed prior to running actions/setup-node
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.pnpm-version }}
+          run_install: false
+
+      - name: Setup Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: pnpm
+          registry-url: 'https://npm.pkg.github.com' # necessary to use NODE_AUTH_TOKEN during pnpm install
+
+      - name: Install dependencies
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGE_READER_PAT }}
+        run: pnpm install --filter "@codemonger-io/passquito-cdk-construct"
+
+      - name: Run tests
+        run: pnpm run -r --filter "@codemonger-io/passquito-cdk-construct" test


### PR DESCRIPTION
Introduces a GitHub Actions workflow `test-passquito-cdk-construct` which runs tests for `passquito-cdk-construct` whenever commits are pushed to any branch except for `main` or a PR is made to the `main` branch.

The `publish-passquito-cdk-construct` runs tests prior to publishing a developer package. This is why the `main` branch is excluded from the trigger branch of the `test-passquito-cdk-construct` workflow.

## Summary by Sourcery

Add a dedicated GitHub Actions test workflow for passquito-cdk-construct and integrate a test step into the publish workflow

CI:
- Introduce `test-passquito-cdk-construct` workflow to run tests on pushes to non-main branches and PRs to main
- Add a test step to the existing `publish-passquito-cdk-construct` workflow to run tests before building the package