### PR TITLE
Add getting started documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,52 @@ Features:
 - [AWS Cognito](https://aws.amazon.com/cognito/) Lambda triggers
 - &#x1F4A9; Ugly codebase
 
+## Getting started
+
+Passquito is consisting of two packages:
+- [`@codemonger-io/passquito-cdk-construct`](./passquito-cdk-construct/) is a CDK construct which describes Passquito core resources on AWS.
+- [`@codemonger-io/passquito-client-js`](./passquito-client-js/) is a JavaScript client library which facilitates the communication with Passquito core resources.
+
+### Steps
+
+1. Add `@codemonger-io/passquito-cdk-construct` to your CDK project (replace `0.0.1-abc1234` with the version you want to install):
+
+    ```sh
+    npm install @codemonger-io/passquito-cdk-construct@0.0.1-abc1234
+    ```
+
+   Note that `@codemonger-io/passquito-cdk-construct` is **only available from the GitHub npm registry** for now.
+   Please refer to the [`README` of `@codemonger-io/passquito-cdk-construct`](./passquito-cdk-construct/README.md#installing-the-package) for more details.
+
+2. Add `@codemonger-io/passquito-client-js` to your web application (replace `0.0.1-abc1234` with the version you want to install):
+
+    ```sh
+    npm install @codemonger-io/passquito-client-js@0.0.1-abc1234
+    ```
+
+   Note that `@codemonger-io/passquito-client-js` is **only available from the GitHub npm registry** for now.
+   Please refer to the [`README` of `@codemonger-io/passquito-client-js`](./passquito-client-js/README.md#installing-the-package) for more details.
+
+3. Include `PassquitoCore` in your CDK stack:
+
+    ```ts
+    import { Stack } from 'aws-cdk-lib';
+    import type { Construct } from 'constructs';
+
+    import { PassquitoCore } from '@codemonger-io/passquito-cdk-construct';
+
+    export class CdkStack extends Stack {
+        constructor(scope: Construct, id: string) {
+            super(scope, id);
+
+            const passquito = new PassquitoCore(this, 'Passquito');
+        }
+    }
+    ```
+
+4. Use `@codemonger-io/passquito-client-js` in your web application to communicate with Passquito core resources.
+   Please refer to the [API documentation](./passquito-client-js/api/markdown/index.md) for how to use it.
+
 ## Usage scenarios in a nutshell
 
 ### Registration

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 
 ## Getting started
 
-Passquito is consisting of two packages:
+Passquito consists of two packages:
 - [`@codemonger-io/passquito-cdk-construct`](./passquito-cdk-construct/) is a CDK construct which describes Passquito core resources on AWS.
 - [`@codemonger-io/passquito-client-js`](./passquito-client-js/) is a JavaScript client library which facilitates the communication with Passquito core resources.
 

--- a/passquito-cdk-construct/README.md
+++ b/passquito-cdk-construct/README.md
@@ -6,7 +6,37 @@
 
 ### Installing the package
 
-TBD: `@codemonger-io/passquito-cdk-construct` is not available on npm yet.
+`@codemonger-io/passquito-cdk-construct` is not available on npm yet.
+Instead, _developer packages_ [^1] are available on the npm registry managed by GitHub Packages.
+You can find packages [here](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
+
+[^1]: A _developer package_ is published to the GitHub npm registry, whenever commits are pushed to the `main` branch of this repository.
+It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.1-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
+
+#### Configuring a GitHub personal access token
+
+To install a developer package, you need to configure a **classic** GitHub personal access token (PAT) with at least the `read:packages` scope.
+Please refer to the [GitHub documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) for how to create a PAT.
+
+Once you have a PAT, create a `.npmrc` file in your home directory with the following content (please replace `$YOUR_GITHUB_PAT` with your actual PAT):
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+In the root directory of your project, create another `.npmrc` file with the following content:
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+Then you can install a _developer package_ with the following command:
+
+```sh
+npm install @codemonger-io/passquito-cdk-construct@0.0.1-abc1234
+```
+
+Please replace `0.0.1-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
 
 ### Example
 

--- a/passquito-client-js/README.md
+++ b/passquito-client-js/README.md
@@ -6,7 +6,37 @@ Passquito client for web applications.
 
 ### Installing the package
 
-TBD: `@codemonger-io/passquito-client-js` is not available on npm yet.
+`@codemonger-io/passquito-client-js` is not available on npm yet.
+Instead, _developer packages_ [^1] are available on the npm registry managed by GitHub Packages.
+You can find packages [here](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-client-js).
+
+[^1]: A _developer package_ is published to the GitHub npm registry, whenever commits are pushed to the `main` branch of this repository.
+It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.1-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
+
+#### Configuring a GitHub personal access token
+
+To install a developer package, you need to configure a **classic** GitHub personal access token (PAT) with at least the `read:packages` scope.
+Please refer to the [GitHub documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) for how to create a PAT.
+
+Once you have a PAT, create a `.npmrc` file in your home directory with the following content (please replace `$YOUR_GITHUB_PAT` with your actual PAT):
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+In the root directory of your project, create another `.npmrc` file with the following content:
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+Then you can install a _developer package_ with the following command:
+
+```sh
+npm install @codemonger-io/passquito-client-js@0.0.1-abc1234
+```
+
+Please replace `0.0.1-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-client-js).
 
 ### API documentation
 


### PR DESCRIPTION
### Proposed changes

- Adds Section "Getting started" to `README.md`
- Explains how to install the packages:
  - `@codemonger-io/passquito-cdk-construct`
  - `@codemonger-io/passquito-client-js`

### Related issues

N/A

## Summary by Sourcery

Provide initial Getting Started documentation for Passquito, detailing how to install and configure the CDK construct and client library from the GitHub npm registry.

Documentation:
- Add a "Getting started" section to the main README with installation steps and a basic usage example.
- Update passquito-cdk-construct README to explain developer package availability on GitHub Packages, PAT setup, .npmrc configuration, and installation command.
- Update passquito-client-js README with similar instructions for GitHub Packages developer packages, including PAT configuration, .npmrc setup, and install command.