### PR TITLE
Set residentKey = "required" in the authenticatorSelection parameter

### DIFF
--- a/passquito-cdk-construct/README.md
+++ b/passquito-cdk-construct/README.md
@@ -11,7 +11,7 @@ Instead, _developer packages_ [^1] are available on the npm registry managed by 
 You can find packages [here](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
 
 [^1]: A _developer package_ is published to the GitHub npm registry, whenever commits are pushed to the `main` branch of this repository.
-It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.3-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
+It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.4-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
 
 #### Configuring a GitHub personal access token
 
@@ -33,10 +33,10 @@ In the root directory of your project, create another `.npmrc` file with the fol
 Then you can install a _developer package_ with the following command:
 
 ```sh
-npm install @codemonger-io/passquito-cdk-construct@0.0.1-abc1234
+npm install @codemonger-io/passquito-cdk-construct@0.0.4-abc1234
 ```
 
-Please replace `0.0.1-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
+Please replace `0.0.4-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
 
 ### Example
 

--- a/passquito-cdk-construct/lambda/authentication/Cargo.lock
+++ b/passquito-cdk-construct/lambda/authentication/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authentication"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aws-config",
  "aws-sdk-cognitoidentityprovider",

--- a/passquito-cdk-construct/lambda/authentication/Cargo.toml
+++ b/passquito-cdk-construct/lambda/authentication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authentication"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Web Authentication with Cognito"
 

--- a/passquito-cdk-construct/lambda/authentication/src/bin/registration.rs
+++ b/passquito-cdk-construct/lambda/authentication/src/bin/registration.rs
@@ -115,7 +115,7 @@ use webauthn_rs::{
         WebauthnError,
     },
 };
-use webauthn_rs_proto::RegisterPublicKeyCredential;
+use webauthn_rs_proto::{RegisterPublicKeyCredential, ResidentKeyRequirement};
 
 use authentication::error_response::ErrorResponse;
 use authentication::parameters::load_relying_party_origin;
@@ -355,6 +355,7 @@ where
         })?;
     // requires a resident key
     if let Some(selection) = ccr.public_key.authenticator_selection.as_mut() {
+        selection.resident_key = Some(ResidentKeyRequirement::Required);
         selection.require_resident_key = true;
     }
     Ok(StartRegistrationSession {
@@ -503,6 +504,7 @@ where
         })?;
     // requires a resident key
     if let Some(selection) = ccr.public_key.authenticator_selection.as_mut() {
+        selection.resident_key = Some(ResidentKeyRequirement::Required);
         selection.require_resident_key = true;
     }
     Ok(StartRegistrationSession {

--- a/passquito-cdk-construct/package.json
+++ b/passquito-cdk-construct/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemonger-io/passquito-cdk-construct",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "CDK construct of Passquito core resources",
   "license": "MIT",
   "author": "Kikuo Emoto <kemoto@codemonger.io>",


### PR DESCRIPTION
### Proposed changes

Fixes the issue that Android did not save any passkey created by Passquito by setting `residentKey = "required"` in the `authenticatorSelection` parameter which is returned when a registration ceremony starts.

### Related issues

- fixes #22

## Summary by Sourcery

Enforce resident key requirement in registration flows and bump versions across the construct, crate, and documentation.

New Features:
- Require resident key in WebAuthn authenticator selection for registration sessions

Enhancements:
- Increase passquito-cdk-construct package version to 0.0.4
- Bump authentication lambda crate version to 0.1.2

Documentation:
- Update README snapshot version examples from 0.0.3 to 0.0.4