### PR TITLE
Make refreshToken not return undefined

### DIFF
--- a/app/src/views/Secured.vue
+++ b/app/src/views/Secured.vue
@@ -58,9 +58,6 @@ const refreshTokens = async () => {
     console.error('invalid refresh tokens response:', err);
     return false;
   }
-  if (newTokens == null) {
-    return false;
-  }
   console.log('refreshed tokens:', newTokens);
   credentialStore.saveTokens(newTokens);
   return true;

--- a/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
+++ b/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
@@ -12,7 +12,7 @@ Refreshes the Cognito tokens associated with a given refresh token.
 **Signature:**
 
 ```typescript
-refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens | undefined>>;
+refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
 ```
 
 ## Parameters
@@ -51,7 +51,7 @@ string
 
 **Returns:**
 
-Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md) \| undefined&gt;&gt;
+Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md)<!-- -->&gt;&gt;
 
-Refreshed Cognito tokens. `undefined` if the refresh token is invalid or expired.
+Refreshed Cognito tokens.
 

--- a/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
+++ b/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
@@ -53,5 +53,5 @@ string
 
 Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md)<!-- -->&gt;&gt;
 
-Refreshed Cognito tokens.
+[ApiResponse](./passquito-client-js.apiresponse.md) that will be resolved as refreshed Cognito tokens. Check the `ok` property to see if the operation has succeeded. If not `ok`<!-- -->, check the `status` property for the reason of failure.
 

--- a/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
+++ b/passquito-client-js/api/markdown/passquito-client-js.credentialsapi.refreshtokens.md
@@ -53,5 +53,5 @@ string
 
 Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md)<!-- -->&gt;&gt;
 
-[ApiResponse](./passquito-client-js.apiresponse.md) that will be resolved as refreshed Cognito tokens. Check the `ok` property to see if the operation has succeeded. If not `ok`<!-- -->, check the `status` property for the reason of failure.
+[ApiResponse](./passquito-client-js.apiresponse.md) that will be resolved with refreshed Cognito tokens. Check the `ok` property to see if the operation has succeeded. If not `ok`<!-- -->, inspect the `status` property for the reason for failure; e.g., you will get `401` for an invalid or expired refresh token.
 

--- a/passquito-client-js/api/markdown/passquito-client-js.credentialsapiimpl.refreshtokens.md
+++ b/passquito-client-js/api/markdown/passquito-client-js.credentialsapiimpl.refreshtokens.md
@@ -10,7 +10,7 @@
 **Signature:**
 
 ```typescript
-refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens | undefined>>;
+refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
 ```
 
 ## Parameters
@@ -49,5 +49,5 @@ string
 
 **Returns:**
 
-Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md) \| undefined&gt;&gt;
+Promise&lt;[ApiResponse](./passquito-client-js.apiresponse.md)<!-- -->&lt;[CognitoTokens](./passquito-client-js.cognitotokens.md)<!-- -->&gt;&gt;
 

--- a/passquito-client-js/api/passquito-client-js.api.md
+++ b/passquito-client-js/api/passquito-client-js.api.md
@@ -46,7 +46,7 @@ export interface CredentialsApi {
     finishAuthentication(sessionId: string, userId: string, credential: PublicKeyCredential): Promise<ApiResponse<CognitoTokens>>;
     finishRegistration(sessionId: string, credential: PublicKeyCredential): Promise<ApiResponse<RegisteredUserInfo>>;
     getDiscoverableCredentialRequestOptions(): Promise<ApiResponse<CredentialRequestOptions>>;
-    refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens | undefined>>;
+    refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
     startAuthentication(userId: string): Promise<ApiResponse<AuthenticationSession>>;
     startRegistration(userInfo: UserInfo): Promise<ApiResponse<RegistrationSession>>;
     startRegistrationForVerifiedUser(userInfo: VerifiedUserInfo): Promise<ApiResponse<RegistrationSession>>;
@@ -63,7 +63,7 @@ export class CredentialsApiImpl implements CredentialsApi {
     // (undocumented)
     getDiscoverableCredentialRequestOptions(): Promise<ApiResponse<CredentialRequestOptions>>;
     // (undocumented)
-    refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens | undefined>>;
+    refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
     // (undocumented)
     startAuthentication(userId: string): Promise<ApiResponse<{
         sessionId: any;

--- a/passquito-client-js/src/credentials-api-impl.ts
+++ b/passquito-client-js/src/credentials-api-impl.ts
@@ -156,7 +156,7 @@ export class CredentialsApiImpl implements CredentialsApi {
     return wrapFetchResponse(res, async (res) => {
       const tokens = await res.json();
       if (!isRawCognitoTokens(tokens)) {
-        return undefined;
+        throw new Error('invalid Cognito tokens');
       }
       return activateCognitoTokens(tokens);
     });

--- a/passquito-client-js/src/credentials-api.ts
+++ b/passquito-client-js/src/credentials-api.ts
@@ -148,9 +148,10 @@ export interface CredentialsApi {
    *
    * @returns
    *
-   *   {@link ApiResponse} that will be resolved as refreshed Cognito tokens.
+   *   {@link ApiResponse} that will be resolved with refreshed Cognito tokens.
    *   Check the `ok` property to see if the operation has succeeded.
-   *   If not `ok`, check the `status` property for the reason of failure.
+   *   If not `ok`, inspect the `status` property for the reason for failure;
+   *   e.g., you will get `401` for an invalid or expired refresh token.
    */
   refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
 }

--- a/passquito-client-js/src/credentials-api.ts
+++ b/passquito-client-js/src/credentials-api.ts
@@ -148,7 +148,9 @@ export interface CredentialsApi {
    *
    * @returns
    *
-   *   Refreshed Cognito tokens.
+   *   {@link ApiResponse} that will be resolved as refreshed Cognito tokens.
+   *   Check the `ok` property to see if the operation has succeeded.
+   *   If not `ok`, check the `status` property for the reason of failure.
    */
   refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
 }

--- a/passquito-client-js/src/credentials-api.ts
+++ b/passquito-client-js/src/credentials-api.ts
@@ -146,8 +146,9 @@ export interface CredentialsApi {
   /**
    * Refreshes the Cognito tokens associated with a given refresh token.
    *
-   * @returns  Refreshed Cognito tokens. `undefined` if the refresh token is
-   *   invalid or expired.
+   * @returns
+   *
+   *   Refreshed Cognito tokens.
    */
-  refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens | undefined>>;
+  refreshTokens(refreshToken: string): Promise<ApiResponse<CognitoTokens>>;
 }


### PR DESCRIPTION
### Proposed changes

A `ApiResponse` returned from the `refreshTokens` method of `CredentialsApi` is no longer parsed as `undefined` when the response body is invalid. It throws an `Error` instead. `ApiResponse` can tell a user more about why token refreshing has failed.

### Related issues

n/a

## Summary by Sourcery

Ensure the credentials refresh flow returns a structured ApiResponse with explicit token validation failures instead of undefined.

Bug Fixes:
- Prevent refreshTokens from silently returning undefined on invalid token responses by surfacing an error through ApiResponse.

Enhancements:
- Simplify client handling of refreshed tokens by guaranteeing a CognitoTokens payload on successful responses.
- Clarify refreshTokens API and generated docs to describe using ApiResponse.ok and status for error handling.

Documentation:
- Update generated API documentation to reflect the new refreshTokens return type and error-handling contract.