### PR TITLE
Reset mediation in discoverable authentication

### DIFF
--- a/passquito-cdk-construct/README.md
+++ b/passquito-cdk-construct/README.md
@@ -11,7 +11,7 @@ Instead, _developer packages_ [^1] are available on the npm registry managed by 
 You can find packages [here](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
 
 [^1]: A _developer package_ is published to the GitHub npm registry, whenever commits are pushed to the `main` branch of this repository.
-It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.6-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
+It has a special version number followed by a dash (`-`) plus a short commit hash; e.g., `0.0.7-abc1234` where `abc1234` is the short commit hash (the first 7 characters) of the commit used to build the package (_snapshot_).
 
 #### Configuring a GitHub personal access token
 
@@ -33,10 +33,10 @@ In the root directory of your project, create another `.npmrc` file with the fol
 Then you can install a _developer package_ with the following command:
 
 ```sh
-npm install @codemonger-io/passquito-cdk-construct@0.0.6-abc1234
+npm install @codemonger-io/passquito-cdk-construct@0.0.7-abc1234
 ```
 
-Please replace `0.0.6-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
+Please replace `0.0.7-abc1234` with the actual version number of the _snapshot_ you want to install, which is available in the [package repository](https://github.com/codemonger-io/passquito/pkgs/npm/passquito-cdk-construct).
 
 ### Example
 

--- a/passquito-cdk-construct/lambda/authentication/Cargo.lock
+++ b/passquito-cdk-construct/lambda/authentication/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authentication"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "aws-config",
  "aws-sdk-cognitoidentityprovider",

--- a/passquito-cdk-construct/lambda/authentication/Cargo.toml
+++ b/passquito-cdk-construct/lambda/authentication/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authentication"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Web Authentication with Cognito"
 

--- a/passquito-cdk-construct/lambda/authentication/src/bin/discoverable.rs
+++ b/passquito-cdk-construct/lambda/authentication/src/bin/discoverable.rs
@@ -100,7 +100,10 @@ async fn start_authentication(
     shared_state: Arc<SharedState>,
 ) -> Result<RequestChallengeResponse, ErrorResponse> {
     info!("start_authentication");
-    let (rcr, auth_state) = shared_state.webauthn.start_discoverable_authentication()?;
+    let (mut rcr, auth_state) = shared_state.webauthn.start_discoverable_authentication()?;
+    // resets the mediation field, as `webauthn-rs` sets it to "conditional"
+    // that users of this library might not expect
+    rcr.mediation = None;
     let ttl = DateTime::from(SystemTime::now() + shared_state.authentication_timeout).secs();
     info!("putting authentication session: {}", base64url.encode(&rcr.public_key.challenge));
     shared_state.dynamodb

--- a/passquito-cdk-construct/package.json
+++ b/passquito-cdk-construct/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemonger-io/passquito-cdk-construct",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "CDK construct of Passquito core resources",
   "license": "MIT",
   "author": "Kikuo Emoto <kemoto@codemonger.io>",


### PR DESCRIPTION
### Proposed changes

- Resets the `mediation` field set to "conditional" by `webauthn-rs`, because users of this library might not expect it.

### Related issues

- closes #43

## Summary by Sourcery

Reset discoverable WebAuthn authentication requests to not specify mediation and bump package versions for a new release.

Bug Fixes:
- Ensure discoverable authentication requests no longer force WebAuthn mediation to "conditional", avoiding unexpected behavior for library consumers.

Build:
- Bump the CDK construct npm package version to 0.0.7 and the authentication lambda crate version to 0.1.4 for release.

Documentation:
- Update README instructions and example developer package version to match the new package release.